### PR TITLE
Add server version resource and doc v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *Ingest and Convert Just About Any Filetype Into AI Workflows*
 
+Current version: v0.2.0
+
 ## Overview
 
 TweekIT MCP Server is the universal media translator for AI workflows, making any file ready for processing in seconds. **Built on the robust content processing engine of Equilibrium's MediaRich Server, a technology developed since 2000 and trusted by massive portals and media companies worldwide, TweekIT brings decades of expertise in handling complex media, drawing on a pedigree that includes the renowned DeBabelizer.**
@@ -381,6 +383,11 @@ TweekIT does not store your files persistently.
 
 Description:
 Fetches the current version of the TweekIT API. Takes no parameters.
+
+#### /server-version
+
+Description:
+Returns this MCP server's version string (e.g., `0.2.0`). Takes no parameters.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *Ingest and Convert Just About Any Filetype Into AI Workflows*
 
-Current version: v0.2.0
+Current version: v0.2.1
 
 ## Overview
 
@@ -387,7 +387,7 @@ Fetches the current version of the TweekIT API. Takes no parameters.
 #### /server-version
 
 Description:
-Returns this MCP server's version string (e.g., `0.2.0`). Takes no parameters.
+Returns this MCP server's version string (e.g., `0.2.1`). Takes no parameters.
 
 ### Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maitrix-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Maitrix/TweekIT MCP server on Cloud Run"
 requires-python = ">=3.10"
 dependencies = [

--- a/server.py
+++ b/server.py
@@ -15,7 +15,7 @@ BASE_URL = "https://dapp.tweekit.io/tweekit/api/image/"
 logger = logging.getLogger(__name__)
 logging.basicConfig(format="[%(levelname)s]: %(message)s", level=logging.WARNING)
 
-SERVER_VERSION = "0.2.0"
+SERVER_VERSION = "0.2.1"
 
 mcp = FastMCP("TweekIT MCP Server - normalize almost any file for AI ingestion")
 

--- a/server.py
+++ b/server.py
@@ -15,6 +15,8 @@ BASE_URL = "https://dapp.tweekit.io/tweekit/api/image/"
 logger = logging.getLogger(__name__)
 logging.basicConfig(format="[%(levelname)s]: %(message)s", level=logging.WARNING)
 
+SERVER_VERSION = "0.2.0"
+
 mcp = FastMCP("TweekIT MCP Server - normalize almost any file for AI ingestion")
 
 @mcp.resource("config://tweekit-version")
@@ -25,6 +27,12 @@ async def version() -> str:
         response = await client.get(url)
         response.raise_for_status()
         return response.text
+
+
+@mcp.resource("config://tweekit-mcp-version")
+async def mcp_version() -> str:
+    """Return the TweekIT MCP server version."""
+    return SERVER_VERSION
 
 @mcp.tool()
 async def doctype(apiKey: str, apiSecret: str, extension: str = "*") -> Dict[str, Any]:


### PR DESCRIPTION
Adds a server-reported version resource and documents v0.2.0.\n\n- New resource: config://tweekit-mcp-version (returns '0.2.0')\n- README: Current version badge and resource section