### PR TITLE
Automate MCP publishing and point to tweekit.io

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,48 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+
+      - name: Run smoke checks
+        run: python -m compileall server.py test_server.py
+
+      - name: Sync server.json version with tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Publishing version ${VERSION}"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Install MCP Publisher CLI
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Cursor loads MCP configuration from `~/.cursor/mcp.json`. To enable the hosted T
   "mcpServers": {
     "tweekit": {
       "type": "http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"
@@ -411,7 +411,7 @@ Continue (VS Code / JetBrains) stores MCP servers in `~/.continue/config.json`. 
   "mcpServers": {
     "tweekit": {
       "type": "streamable-http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"

--- a/claude/README.md
+++ b/claude/README.md
@@ -7,7 +7,7 @@ This bundle configures Claude Desktop to connect to the hosted TweekIT MCP serve
 - `README.md` – quick reference for operators.
 
 ## Customization Checklist
-1. Replace `entry_point.url` with the production MCP endpoint (defaults to `https://mcp.tweekit.com/mcp`).
+1. Replace `entry_point.url` with the production MCP endpoint (defaults to `https://mcp.tweekit.io/mcp`).
 2. Confirm the required environment variables match your authentication model.
 3. Bump the `version` and update the changelog when shipping edits.
 

--- a/claude/manifest.json
+++ b/claude/manifest.json
@@ -8,7 +8,7 @@
   "entry_point": {
     "type": "remote_http",
     "transport": "streamable-http",
-    "url": "https://mcp.tweekit.com/mcp"
+    "url": "https://mcp.tweekit.io/mcp"
   },
   "environment": [
     {

--- a/clients/python/tweekit_client.py
+++ b/clients/python/tweekit_client.py
@@ -34,7 +34,7 @@ class TweekitClient:
         api_key: str | None = None,
         api_secret: str | None = None,
     ) -> None:
-        self.server_url = server_url or os.getenv("TWEEKIT_MCP_SERVER", "https://mcp.tweekit.com/mcp")
+        self.server_url = server_url or os.getenv("TWEEKIT_MCP_SERVER", "https://mcp.tweekit.io/mcp")
         self.api_key = api_key or os.getenv("TWEEKIT_API_KEY")
         self.api_secret = api_secret or os.getenv("TWEEKIT_API_SECRET")
         self._client: Client | None = None

--- a/configs/continue-mcp.json
+++ b/configs/continue-mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "tweekit": {
       "type": "streamable-http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"

--- a/configs/cursor-mcp.json
+++ b/configs/cursor-mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "tweekit": {
       "type": "http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"

--- a/configs/inspector-mcp.json
+++ b/configs/inspector-mcp.json
@@ -20,7 +20,7 @@
     },
     "tweekit-production": {
       "type": "streamable-http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "note": "Production MCP endpoint; requires valid API credentials.",
       "headers": {
         "ApiKey": "<YOUR_TWEEKIT_API_KEY>",

--- a/docs/claude-bundle.md
+++ b/docs/claude-bundle.md
@@ -3,7 +3,7 @@
 This guide explains how to package and distribute the TweekIT MCP server for Anthropic Claude Desktop using the `.mcpb` bundle format.
 
 ## Overview
-- The bundle references the hosted streamable HTTP endpoint (`https://mcp.tweekit.com/mcp` by default).
+- The bundle references the hosted streamable HTTP endpoint (`https://mcp.tweekit.io/mcp` by default).
 - Users supply their TweekIT credentials through Claude's environment settings when importing the bundle.
 - The build script emits `dist/tweekit-claude.mcpb`, which Claude Desktop can install with one click.
 
@@ -21,7 +21,7 @@ Edit `claude/manifest.json` to ensure:
 ## Build the Bundle
 ```bash
 python scripts/build_claude_bundle.py \
-  --server-url https://mcp.tweekit.com/mcp \
+  --server-url https://mcp.tweekit.io/mcp \
   --version 0.1.0 \
   --output dist/tweekit-claude.mcpb
 ```

--- a/docs/deepseek-integration.md
+++ b/docs/deepseek-integration.md
@@ -11,7 +11,7 @@ DeepSeek does not yet provide a first-class MCP connector, but teams can still i
 python scripts/deepseek_mcp_bridge.py \
   --file path/to/input.pdf \
   --outfmt txt \
-  --server https://mcp.tweekit.com/mcp \
+  --server https://mcp.tweekit.io/mcp \
   --api-key "$TWEEKIT_API_KEY" \
   --api-secret "$TWEEKIT_API_SECRET" \
   --output converted.txt
@@ -25,7 +25,7 @@ The script invokes the MCP `convert` tool via `fastmcp.Client`, writing any base
 - **Credential handling:** Provide `TWEEKIT_API_KEY`/`TWEEKIT_API_SECRET` via environment variables or parameter flags; rotate keys through your secrets manager.
 
 ## Future Native Integration
-- Monitor DeepSeek announcements for MCP or plugin support. Once official hooks exist, reuse the same configuration (`https://mcp.tweekit.com/mcp`) and tool names (`version`, `doctype`, `convert`).
+- Monitor DeepSeek announcements for MCP or plugin support. Once official hooks exist, reuse the same configuration (`https://mcp.tweekit.io/mcp`) and tool names (`version`, `doctype`, `convert`).
 - Prepare a DeepSeek-specific manifest mirroring the ChatGPT plugin proxy if their platform adopts an OpenAPI-based registration system.
 - Add automated tests that validate TweekIT responses through DeepSeek’s tooling as soon as beta access becomes available.
 

--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -1,6 +1,6 @@
 # Developer Tool Integrations
 
-This guide summarizes how to connect the hosted TweekIT MCP server to popular IDE assistants and automation environments. Update the URLs if you run your own deployment (defaults assume `https://mcp.tweekit.com/mcp`).
+This guide summarizes how to connect the hosted TweekIT MCP server to popular IDE assistants and automation environments. Update the URLs if you run your own deployment (defaults assume `https://mcp.tweekit.io/mcp`).
 
 ## Cursor
 Cursor reads configuration from `~/.cursor/mcp.json`. Merge the snippet below (also available at `configs/cursor-mcp.json`) into that file or publish it through an “Add to Cursor” link on your docs site.
@@ -10,7 +10,7 @@ Cursor reads configuration from `~/.cursor/mcp.json`. Merge the snippet below (a
   "mcpServers": {
     "tweekit": {
       "type": "http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"
@@ -33,7 +33,7 @@ Continue stores MCP servers in `~/.continue/config.json`. Add the following entr
   "mcpServers": {
     "tweekit": {
       "type": "streamable-http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": {
         "ApiKey": "${TWEEKIT_API_KEY}",
         "ApiSecret": "${TWEEKIT_API_SECRET}"

--- a/docs/grok-integration.md
+++ b/docs/grok-integration.md
@@ -11,7 +11,7 @@ This document captures the current path to enable TweekIT MCP inside xAI’s Gro
 1. Install the MCP SuperAssistant browser extension (Chrome/Edge) from the web store.
 2. Open the extension options and add a server entry:
    - **Name:** TweekIT Converter
-   - **URL:** `https://mcp.tweekit.com/mcp` (update as needed)
+   - **URL:** `https://mcp.tweekit.io/mcp` (update as needed)
    - **Transport:** `streamable-http`
    - Provide `TWEEKIT_API_KEY`/`SECRET` in the extension’s credential fields.
 3. Enable Grok (plus any other supported chat UIs) inside the extension.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,7 +69,7 @@ Replace the placeholder URLs with your own staging project IDs. We intentionally
 
 ```bash
 uv run python scripts/run_mcp_e2e.py \
-  --server-url https://mcp.tweekit.com/mcp/ \
+  --server-url https://mcp.tweekit.io/mcp/ \
   --credentials-file .tweekit_prod_credentials \
   --include-convert-url \
   --output-dir tests/output/prod
@@ -81,7 +81,7 @@ Add `--save-credentials` the first time you run each command to persist the prom
 Useful when pointed at staging/production endpoints. It calls each tool, validates binary responses, and reports missing checks.
 
 ```bash
-uv run python test_server.py --base-url https://mcp.tweekit.com/mcp/
+uv run python test_server.py --base-url https://mcp.tweekit.io/mcp/
 ```
 
 ### 1.4 Coverage Gaps & TODOs
@@ -109,7 +109,7 @@ Run these steps for release candidates, major refactors, or whenever UI/manifest
 
 ### 2.3 ChatGPT MCP (Custom GPT / Tools panel)
 1. Configure an MCP server with URL + headers:
-   - URL: `https://mcp.tweekit.com/mcp/` (or staging).
+   - URL: `https://mcp.tweekit.io/mcp/` (or staging).
    - Headers: `ApiKey`, `ApiSecret`.
 2. In a chat, run:
    - `doctype` for `pdf`.

--- a/examples/node/quickstart.mjs
+++ b/examples/node/quickstart.mjs
@@ -14,7 +14,7 @@ import { argv } from "node:process";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
-const DEFAULT_SERVER = process.env.TWEEKIT_MCP_SERVER ?? "https://mcp.tweekit.com/mcp";
+const DEFAULT_SERVER = process.env.TWEEKIT_MCP_SERVER ?? "https://mcp.tweekit.io/mcp";
 const API_KEY = process.env.TWEEKIT_API_KEY;
 const API_SECRET = process.env.TWEEKIT_API_SECRET;
 

--- a/scripts/build_claude_bundle.py
+++ b/scripts/build_claude_bundle.py
@@ -4,7 +4,7 @@ Build a Claude Desktop MCP bundle (.mcpb) for the TweekIT server.
 
 Usage:
     python scripts/build_claude_bundle.py \
-        --server-url https://mcp.tweekit.com/mcp \
+        --server-url https://mcp.tweekit.io/mcp \
         --version 0.1.0 \
         --output dist/tweekit-claude.mcpb
 """

--- a/scripts/deepseek_mcp_bridge.py
+++ b/scripts/deepseek_mcp_bridge.py
@@ -6,7 +6,7 @@ Example usage:
     python scripts/deepseek_mcp_bridge.py \
         --file sample.pdf \
         --outfmt txt \
-        --server https://mcp.tweekit.com/mcp
+        --server https://mcp.tweekit.io/mcp
 """
 
 from __future__ import annotations
@@ -66,7 +66,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Call the TweekIT convert tool for DeepSeek workflows.")
     parser.add_argument("--file", required=True, type=Path, help="Path to the input document.")
     parser.add_argument("--outfmt", required=True, help="Target output format (e.g. pdf, txt, png).")
-    parser.add_argument("--server", default="https://mcp.tweekit.com/mcp", help="TweekIT MCP server URL.")
+    parser.add_argument("--server", default="https://mcp.tweekit.io/mcp", help="TweekIT MCP server URL.")
     parser.add_argument("--api-key", default=None, help="TweekIT API key (overrides env variable).")
     parser.add_argument("--api-secret", default=None, help="TweekIT API secret (overrides env variable).")
     parser.add_argument("--width", type=int, default=0, help="Resize width in pixels (optional).")

--- a/server.json
+++ b/server.json
@@ -13,7 +13,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://mcp.tweekit.com/mcp",
+      "url": "https://mcp.tweekit.io/mcp",
       "headers": [
         {
           "name": "ApiKey",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.equilibrium-team/tweekit",
+  "title": "TweekIT MCP Server",
+  "description": "Normalize and convert more than 400 file types via TweekIT's hosted MCP streamable HTTP endpoint.",
+  "version": "1.5.0",
+  "websiteUrl": "https://www.tweekit.io/",
+  "repository": {
+    "source": "github",
+    "id": "1032125130",
+    "url": "https://github.com/equilibrium-team/tweekit-mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.tweekit.com/mcp",
+      "headers": [
+        {
+          "name": "ApiKey",
+          "description": "TweekIT API key issued from the TweekIT account portal.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "ApiSecret",
+          "description": "API secret paired with the ApiKey for authenticated conversions.",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add server.json manifest and GitHub Actions workflow for automated registry publishing via GitHub OIDC
- update all configs/docs/manifests to use the correct https://mcp.tweekit.io/mcp endpoint
- harden config resource error handling so upstream outages don’t break discovery checks

## Testing
- jsonschema.validate server.json
- uv run python -m compileall server.py test_server.py
